### PR TITLE
feat: Automatically include sandbox in MPRokt Attributes

### DIFF
--- a/mParticle-Rokt.xcodeproj/project.pbxproj
+++ b/mParticle-Rokt.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		536803952B7BAE11000A10BE /* mParticle-Apple-SDK in Frameworks */ = {isa = PBXBuildFile; productRef = 536803942B7BAE11000A10BE /* mParticle-Apple-SDK */; };
 		7E15B2092D9AE82000C1FF3E /* mParticle-Apple-SDK in Frameworks */ = {isa = PBXBuildFile; productRef = 7E15B2082D9AE82000C1FF3E /* mParticle-Apple-SDK */; };
 		7E15B20B2D9AE82600C1FF3E /* Rokt-Widget in Frameworks */ = {isa = PBXBuildFile; productRef = 7E15B20A2D9AE82600C1FF3E /* Rokt-Widget */; };
+		7EE7F13E2DA95BEE006C5440 /* OCMock in Frameworks */ = {isa = PBXBuildFile; productRef = 7EE7F13D2DA95BEE006C5440 /* OCMock */; };
 		DBB01A601DC1478A00A7B188 /* mParticle_Rokt.h in Headers */ = {isa = PBXBuildFile; fileRef = DBB01A5E1DC1478A00A7B188 /* mParticle_Rokt.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBB01A681DC1480700A7B188 /* MPKitRokt.h in Headers */ = {isa = PBXBuildFile; fileRef = DBB01A661DC1480700A7B188 /* MPKitRokt.h */; };
 		DBB01A691DC1480700A7B188 /* MPKitRokt.m in Sources */ = {isa = PBXBuildFile; fileRef = DBB01A671DC1480700A7B188 /* MPKitRokt.m */; };
@@ -55,6 +56,7 @@
 			files = (
 				7E15B2092D9AE82000C1FF3E /* mParticle-Apple-SDK in Frameworks */,
 				FF0BB640217A84E800B0556C /* mParticle_Rokt.framework in Frameworks */,
+				7EE7F13E2DA95BEE006C5440 /* OCMock in Frameworks */,
 				7E15B20B2D9AE82600C1FF3E /* Rokt-Widget in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -194,6 +196,7 @@
 			packageReferences = (
 				536803932B7BAE11000A10BE /* XCRemoteSwiftPackageReference "mparticle-apple-sdk" */,
 				2502325A2D7A7BF3004794A2 /* XCRemoteSwiftPackageReference "rokt-sdk-ios" */,
+				7EE7F13C2DA95BEE006C5440 /* XCRemoteSwiftPackageReference "ocmock" */,
 			);
 			productRefGroup = DBB01A5C1DC1478A00A7B188 /* Products */;
 			projectDirPath = "";
@@ -520,6 +523,14 @@
 				minimumVersion = 8.4.0;
 			};
 		};
+		7EE7F13C2DA95BEE006C5440 /* XCRemoteSwiftPackageReference "ocmock" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/erikdoe/ocmock.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -542,6 +553,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2502325A2D7A7BF3004794A2 /* XCRemoteSwiftPackageReference "rokt-sdk-ios" */;
 			productName = "Rokt-Widget";
+		};
+		7EE7F13D2DA95BEE006C5440 /* OCMock */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7EE7F13C2DA95BEE006C5440 /* XCRemoteSwiftPackageReference "ocmock" */;
+			productName = OCMock;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/mParticle-Rokt/MPKitRokt.m
+++ b/mParticle-Rokt/MPKitRokt.m
@@ -104,6 +104,7 @@ NSString * const MPKitRoktErrorMessageKey = @"mParticle-Rokt Error";
     if (filteredUser.userId.stringValue != nil) {
         [finalAtt addEntriesFromDictionary:@{@"mpid": filteredUser.userId.stringValue}];
     }
+    // The core SDK does not set sandbox on the user, but we must pass it to Rokt if provided
     NSString *sandboxKey = @"sandbox";
     if (attributes[sandboxKey] != nil) {
         [finalAtt addEntriesFromDictionary:@{sandboxKey: attributes[sandboxKey]}];

--- a/mParticle-Rokt/MPKitRokt.m
+++ b/mParticle-Rokt/MPKitRokt.m
@@ -100,10 +100,14 @@ NSString * const MPKitRoktErrorMessageKey = @"mParticle-Rokt Error";
                             filteredUser:(FilteredMParticleUser * _Nonnull)filteredUser {
     NSDictionary<NSString *, NSString *> *mpAttributes = [filteredUser.userAttributes transformValuesToString];
     NSMutableDictionary<NSString *, NSString *> *finalAtt = [[NSMutableDictionary alloc] init];
-    if (filteredUser.userId.stringValue) {
+    [finalAtt addEntriesFromDictionary:mpAttributes];
+    if (filteredUser.userId.stringValue != nil) {
         [finalAtt addEntriesFromDictionary:@{@"mpid": filteredUser.userId.stringValue}];
     }
-    [finalAtt addEntriesFromDictionary:mpAttributes];
+    NSString *sandboxKey = @"sandbox";
+    if (attributes[sandboxKey] != nil) {
+        [finalAtt addEntriesFromDictionary:@{sandboxKey: attributes[sandboxKey]}];
+    }
     
     [Rokt executeWithViewName:viewName
                    attributes:finalAtt

--- a/mParticle_RoktTests/mParticle_RoktTests.m
+++ b/mParticle_RoktTests/mParticle_RoktTests.m
@@ -1,4 +1,5 @@
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
 #import <Rokt_Widget/Rokt_Widget-Swift.h>
 #import "MPKitRokt.h"
 
@@ -118,12 +119,30 @@
 }
 
 - (void)testExecuteWithViewName {
+    id mockRoktSDK = OCMClassMock([Rokt class]);
+
     RoktEmbeddedView *view = [[RoktEmbeddedView alloc] init];
+    NSString *viewName = @"TestView";
     NSDictionary *placements = @{@"placement1": view};
-    NSDictionary *attributes = @{@"attr1": @"value1"};
+    NSDictionary *attributes = @{@"attr1": @"value1", @"sandbox": @"true"};
     FilteredMParticleUser *user = [[FilteredMParticleUser alloc] init];
     
-    MPKitExecStatus *status = [self.kitInstance executeWithViewName:@"TestView"
+    // Expected attributes in final call
+    NSDictionary *expectedAttributes = @{
+        @"sandbox": @"true"
+    };
+
+    // Expect Rokt execute call with correct parameters
+    OCMExpect([mockRoktSDK executeWithViewName:@"TestView"
+                                   attributes:expectedAttributes
+                                   placements:placements
+                                       onLoad:nil
+                                     onUnLoad:nil
+                 onShouldShowLoadingIndicator:nil
+                 onShouldHideLoadingIndicator:nil
+                         onEmbeddedSizeChange:nil]);
+    
+    MPKitExecStatus *status = [self.kitInstance executeWithViewName:viewName
                                                        attributes:attributes
                                                        placements:placements
                                                            onLoad:nil
@@ -132,9 +151,11 @@
                                      onShouldHideLoadingIndicator:nil
                                              onEmbeddedSizeChange:nil
                                                      filteredUser:user];
-    
+
+    // Verify
     XCTAssertNotNil(status);
     XCTAssertEqual(status.returnCode, MPKitReturnCodeSuccess);
+    OCMVerifyAll(mockRoktSDK);
 }
 
 @end 


### PR DESCRIPTION
## Summary
 - Take "sandbox" out of attributes and add it to the data being sent to Rokt.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with my sample app alongside chsnges to core

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7205
