### PR TITLE
feat: Add Known Identities to Passed Rokt Attributes

### DIFF
--- a/mParticle-Rokt/MPKitRokt.m
+++ b/mParticle-Rokt/MPKitRokt.m
@@ -90,9 +90,15 @@ NSString * const MPKitRoktErrorMessageKey = @"mParticle-Rokt Error";
     NSDictionary<NSString *, NSString *> *mpAttributes = [filteredUser.userAttributes transformValuesToString];
     NSMutableDictionary<NSString *, NSString *> *finalAtt = [[NSMutableDictionary alloc] init];
     [finalAtt addEntriesFromDictionary:mpAttributes];
+    
+    // Add MPID to the attributes being passed to the Rokt SDK
     if (filteredUser.userId.stringValue != nil) {
         [finalAtt addEntriesFromDictionary:@{@"mpid": filteredUser.userId.stringValue}];
     }
+    
+    // Add all known user identities to the attributes being passed to the Rokt SDK
+    [self addIdentityAttributes:finalAtt filteredUser:filteredUser];
+    
     // The core SDK does not set sandbox on the user, but we must pass it to Rokt if provided
     NSString *sandboxKey = @"sandbox";
     if (attributes[sandboxKey] != nil) {
@@ -124,6 +130,102 @@ NSString * const MPKitRoktErrorMessageKey = @"mParticle-Rokt Error";
     }
     
     return safePlacements;
+}
+
+- (void)addIdentityAttributes:(NSMutableDictionary<NSString *, NSString *> * _Nullable)attributes filteredUser:(FilteredMParticleUser * _Nonnull)filteredUser {
+    NSMutableDictionary<NSString *, NSString *> *identityAttributes = [[NSMutableDictionary alloc] init];
+    for (NSNumber *identityNumberKey in filteredUser.userIdentities) {
+        NSString *identityStringKey = [MPKitRokt stringForIdentityType:identityNumberKey.unsignedIntegerValue];
+        [identityAttributes setObject:filteredUser.userIdentities[identityNumberKey] forKey:identityStringKey];
+    }
+    
+    if (attributes != nil) {
+        [attributes addEntriesFromDictionary:identityAttributes];
+    } else {
+        attributes = identityAttributes;
+    }
+}
+
++ (NSString *)stringForIdentityType:(MPIdentity)identityType {
+    switch (identityType) {
+        case MPIdentityCustomerId:
+            return @"customerid";
+            
+        case MPIdentityEmail:
+            return @"email";
+            
+        case MPIdentityFacebook:
+            return @"facebook";
+            
+        case MPIdentityFacebookCustomAudienceId:
+            return @"facebookcustomaudienceid";
+            
+        case MPIdentityGoogle:
+            return @"google";
+            
+        case MPIdentityMicrosoft:
+            return @"microsoft";
+            
+        case MPIdentityOther:
+            return @"other";
+            
+        case MPIdentityTwitter:
+            return @"twitter";
+            
+        case MPIdentityYahoo:
+            return @"yahoo";
+            
+        case MPIdentityOther2:
+            return @"other2";
+            
+        case MPIdentityOther3:
+            return @"other3";
+            
+        case MPIdentityOther4:
+            return @"other4";
+            
+        case MPIdentityOther5:
+            return @"other5";
+            
+        case MPIdentityOther6:
+            return @"other6";
+            
+        case MPIdentityOther7:
+            return @"other7";
+            
+        case MPIdentityOther8:
+            return @"other8";
+            
+        case MPIdentityOther9:
+            return @"other9";
+            
+        case MPIdentityOther10:
+            return @"other10";
+            
+        case MPIdentityMobileNumber:
+            return @"mobile_number";
+            
+        case MPIdentityPhoneNumber2:
+            return @"phone_number_2";
+            
+        case MPIdentityPhoneNumber3:
+            return @"phone_number_3";
+            
+        case MPIdentityIOSAdvertiserId:
+            return @"ios_idfa";
+            
+        case MPIdentityIOSVendorId:
+            return @"ios_idfv";
+            
+        case MPIdentityPushToken:
+            return @"push_token";
+            
+        case MPIdentityDeviceApplicationStamp:
+            return @"device_application_stamp";
+            
+        default:
+            return nil;
+    }
 }
 
 #pragma mark - User attributes and identities

--- a/mParticle_RoktTests/mParticle_RoktTests.m
+++ b/mParticle_RoktTests/mParticle_RoktTests.m
@@ -14,6 +14,8 @@
 - (NSDictionary<NSString *, RoktEmbeddedView *> * _Nullable) confirmPlacements:(NSDictionary<NSString *, RoktEmbeddedView *> * _Nullable)placements;
 
 - (NSDictionary<NSString *, NSString *> *) filteredUserAttributes:(NSDictionary<NSString *, NSString *> * _Nonnull)attributes kitConfiguration:(MPKitConfiguration *)kitConfiguration;
+
+- (void)addIdentityAttributes:(NSMutableDictionary<NSString *, NSString *> * _Nullable)attributes filteredUser:(FilteredMParticleUser * _Nonnull)filteredUser;
     
 @end
 
@@ -148,6 +150,23 @@
     XCTAssertNotNil(status);
     XCTAssertEqual(status.returnCode, MPKitReturnCodeSuccess);
     OCMVerifyAll(mockRoktSDK);
+}
+
+- (void)testAddIdentityAttributes {
+    NSMutableDictionary<NSString *, NSString *> *passedAttributes = [[NSMutableDictionary alloc] init];
+    NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityEmail): @"testEmail@gmail.com",
+                                                             @(MPIdentityOther): @"testUserName",
+                                                             @(MPIdentityMobileNumber): @"1(234)-567-8910"};
+    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] init];
+    id mockfilteredUser = OCMPartialMock(filteredUser);
+    [[[mockfilteredUser stub] andReturn:testIdentities] userIdentities];
+    
+    MPKitRokt *kit = [[MPKitRokt alloc] init];
+    [kit addIdentityAttributes:passedAttributes filteredUser:filteredUser];
+    
+    XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
+    XCTAssertEqualObjects(passedAttributes[@"other"], @"testUserName");
+    XCTAssertEqualObjects(passedAttributes[@"mobile_number"], @"1(234)-567-8910");
 }
 
 @end 

--- a/mParticle_RoktTests/mParticle_RoktTests.m
+++ b/mParticle_RoktTests/mParticle_RoktTests.m
@@ -154,9 +154,32 @@
 
 - (void)testAddIdentityAttributes {
     NSMutableDictionary<NSString *, NSString *> *passedAttributes = [[NSMutableDictionary alloc] init];
-    NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityEmail): @"testEmail@gmail.com",
-                                                             @(MPIdentityOther): @"testUserName",
-                                                             @(MPIdentityMobileNumber): @"1(234)-567-8910"};
+    NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityCustomerId): @"testCustomerID",
+                                                             @(MPIdentityEmail): @"testEmail@gmail.com",
+                                                             @(MPIdentityFacebook): @"testFacebook",
+                                                             @(MPIdentityFacebookCustomAudienceId): @"testCustomAudienceID",
+                                                             @(MPIdentityGoogle): @"testGoogle",
+                                                             @(MPIdentityMicrosoft): @"testMicrosoft",
+                                                             @(MPIdentityOther): @"testOther",
+                                                             @(MPIdentityTwitter): @"testTwitter",
+                                                             @(MPIdentityYahoo): @"testYahoo",
+                                                             @(MPIdentityOther2): @"testOther2",
+                                                             @(MPIdentityOther3): @"testOther3",
+                                                             @(MPIdentityOther4): @"testOther4",
+                                                             @(MPIdentityOther5): @"testOther5",
+                                                             @(MPIdentityOther6): @"testOther6",
+                                                             @(MPIdentityOther7): @"testOther7",
+                                                             @(MPIdentityOther8): @"testOther8",
+                                                             @(MPIdentityOther9): @"testOther9",
+                                                             @(MPIdentityOther10): @"testOther10",
+                                                             @(MPIdentityMobileNumber): @"1(234)-567-8910",
+                                                             @(MPIdentityPhoneNumber2): @"1(234)-567-2222",
+                                                             @(MPIdentityPhoneNumber3): @"1(234)-567-3333",
+                                                             @(MPIdentityIOSAdvertiserId): @"testAdvertID",
+                                                             @(MPIdentityIOSVendorId): @"testVendorID",
+                                                             @(MPIdentityPushToken): @"testPushToken",
+                                                             @(MPIdentityDeviceApplicationStamp): @"Test DAS"};
+
     FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] init];
     id mockfilteredUser = OCMPartialMock(filteredUser);
     [[[mockfilteredUser stub] andReturn:testIdentities] userIdentities];
@@ -164,9 +187,95 @@
     MPKitRokt *kit = [[MPKitRokt alloc] init];
     [kit addIdentityAttributes:passedAttributes filteredUser:filteredUser];
     
+    XCTAssertEqualObjects(passedAttributes[@"customerid"], @"testCustomerID");
     XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
-    XCTAssertEqualObjects(passedAttributes[@"other"], @"testUserName");
+    XCTAssertEqualObjects(passedAttributes[@"facebook"], @"testFacebook");
+    XCTAssertEqualObjects(passedAttributes[@"facebookcustomaudienceid"], @"testCustomAudienceID");
+    XCTAssertEqualObjects(passedAttributes[@"google"], @"testGoogle");
+    XCTAssertEqualObjects(passedAttributes[@"microsoft"], @"testMicrosoft");
+    XCTAssertEqualObjects(passedAttributes[@"other"], @"testOther");
+    XCTAssertEqualObjects(passedAttributes[@"twitter"], @"testTwitter");
+    XCTAssertEqualObjects(passedAttributes[@"yahoo"], @"testYahoo");
+    XCTAssertEqualObjects(passedAttributes[@"other2"], @"testOther2");
+    XCTAssertEqualObjects(passedAttributes[@"other3"], @"testOther3");
+    XCTAssertEqualObjects(passedAttributes[@"other4"], @"testOther4");
+    XCTAssertEqualObjects(passedAttributes[@"other5"], @"testOther5");
+    XCTAssertEqualObjects(passedAttributes[@"other6"], @"testOther6");
+    XCTAssertEqualObjects(passedAttributes[@"other7"], @"testOther7");
+    XCTAssertEqualObjects(passedAttributes[@"other8"], @"testOther8");
+    XCTAssertEqualObjects(passedAttributes[@"other9"], @"testOther9");
+    XCTAssertEqualObjects(passedAttributes[@"other10"], @"testOther10");
     XCTAssertEqualObjects(passedAttributes[@"mobile_number"], @"1(234)-567-8910");
+    XCTAssertEqualObjects(passedAttributes[@"phone_number_2"], @"1(234)-567-2222");
+    XCTAssertEqualObjects(passedAttributes[@"phone_number_3"], @"1(234)-567-3333");
+    XCTAssertEqualObjects(passedAttributes[@"ios_idfa"], @"testAdvertID");
+    XCTAssertEqualObjects(passedAttributes[@"ios_idfv"], @"testVendorID");
+    XCTAssertEqualObjects(passedAttributes[@"push_token"], @"testPushToken");
+    XCTAssertEqualObjects(passedAttributes[@"device_application_stamp"], @"Test DAS");
+}
+
+- (void)testAddIdentityAttributesWithExistingAttributes {
+    NSMutableDictionary<NSString *, NSString *> *passedAttributes = [[NSMutableDictionary alloc] init];
+    [passedAttributes setObject:@"bar" forKey:@"foo"];
+    NSDictionary<NSNumber *, NSString *> *testIdentities = @{@(MPIdentityCustomerId): @"testCustomerID",
+                                                             @(MPIdentityEmail): @"testEmail@gmail.com",
+                                                             @(MPIdentityFacebook): @"testFacebook",
+                                                             @(MPIdentityFacebookCustomAudienceId): @"testCustomAudienceID",
+                                                             @(MPIdentityGoogle): @"testGoogle",
+                                                             @(MPIdentityMicrosoft): @"testMicrosoft",
+                                                             @(MPIdentityOther): @"testOther",
+                                                             @(MPIdentityTwitter): @"testTwitter",
+                                                             @(MPIdentityYahoo): @"testYahoo",
+                                                             @(MPIdentityOther2): @"testOther2",
+                                                             @(MPIdentityOther3): @"testOther3",
+                                                             @(MPIdentityOther4): @"testOther4",
+                                                             @(MPIdentityOther5): @"testOther5",
+                                                             @(MPIdentityOther6): @"testOther6",
+                                                             @(MPIdentityOther7): @"testOther7",
+                                                             @(MPIdentityOther8): @"testOther8",
+                                                             @(MPIdentityOther9): @"testOther9",
+                                                             @(MPIdentityOther10): @"testOther10",
+                                                             @(MPIdentityMobileNumber): @"1(234)-567-8910",
+                                                             @(MPIdentityPhoneNumber2): @"1(234)-567-2222",
+                                                             @(MPIdentityPhoneNumber3): @"1(234)-567-3333",
+                                                             @(MPIdentityIOSAdvertiserId): @"testAdvertID",
+                                                             @(MPIdentityIOSVendorId): @"testVendorID",
+                                                             @(MPIdentityPushToken): @"testPushToken",
+                                                             @(MPIdentityDeviceApplicationStamp): @"Test DAS"};
+
+    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] init];
+    id mockfilteredUser = OCMPartialMock(filteredUser);
+    [[[mockfilteredUser stub] andReturn:testIdentities] userIdentities];
+    
+    MPKitRokt *kit = [[MPKitRokt alloc] init];
+    [kit addIdentityAttributes:passedAttributes filteredUser:filteredUser];
+    
+    XCTAssertEqualObjects(passedAttributes[@"foo"], @"bar");
+    XCTAssertEqualObjects(passedAttributes[@"customerid"], @"testCustomerID");
+    XCTAssertEqualObjects(passedAttributes[@"email"], @"testEmail@gmail.com");
+    XCTAssertEqualObjects(passedAttributes[@"facebook"], @"testFacebook");
+    XCTAssertEqualObjects(passedAttributes[@"facebookcustomaudienceid"], @"testCustomAudienceID");
+    XCTAssertEqualObjects(passedAttributes[@"google"], @"testGoogle");
+    XCTAssertEqualObjects(passedAttributes[@"microsoft"], @"testMicrosoft");
+    XCTAssertEqualObjects(passedAttributes[@"other"], @"testOther");
+    XCTAssertEqualObjects(passedAttributes[@"twitter"], @"testTwitter");
+    XCTAssertEqualObjects(passedAttributes[@"yahoo"], @"testYahoo");
+    XCTAssertEqualObjects(passedAttributes[@"other2"], @"testOther2");
+    XCTAssertEqualObjects(passedAttributes[@"other3"], @"testOther3");
+    XCTAssertEqualObjects(passedAttributes[@"other4"], @"testOther4");
+    XCTAssertEqualObjects(passedAttributes[@"other5"], @"testOther5");
+    XCTAssertEqualObjects(passedAttributes[@"other6"], @"testOther6");
+    XCTAssertEqualObjects(passedAttributes[@"other7"], @"testOther7");
+    XCTAssertEqualObjects(passedAttributes[@"other8"], @"testOther8");
+    XCTAssertEqualObjects(passedAttributes[@"other9"], @"testOther9");
+    XCTAssertEqualObjects(passedAttributes[@"other10"], @"testOther10");
+    XCTAssertEqualObjects(passedAttributes[@"mobile_number"], @"1(234)-567-8910");
+    XCTAssertEqualObjects(passedAttributes[@"phone_number_2"], @"1(234)-567-2222");
+    XCTAssertEqualObjects(passedAttributes[@"phone_number_3"], @"1(234)-567-3333");
+    XCTAssertEqualObjects(passedAttributes[@"ios_idfa"], @"testAdvertID");
+    XCTAssertEqualObjects(passedAttributes[@"ios_idfv"], @"testVendorID");
+    XCTAssertEqualObjects(passedAttributes[@"push_token"], @"testPushToken");
+    XCTAssertEqualObjects(passedAttributes[@"device_application_stamp"], @"Test DAS");
 }
 
 @end 


### PR DESCRIPTION
## Summary
 - The plan is to add the identities to the attributes dictionary that's being sent to the Rokt SDK (their keys will match [these](https://github.com/mParticle/mparticle-apple-sdk/blob/9298c78ef927f3b0b1cdcca53e6e63940ab09628/mParticle-Apple-SDK/Identity/MPIdentityDTO.m#L448) strings). This will be done on the kit side using the filteredUser that's passed in already (edited)

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested using sample app and added unit test

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7188
