### PR TITLE
feat: Create No Location Target for ROKT Kit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
         .library(
             name: "mParticle-Rokt",
             targets: ["mParticle-Rokt-Swift"]),
+        .library(
+            name: "mParticle-Rokt-NoLocation",
+            targets: ["mParticle-Rokt-Swift-NoLocation"]),
     ],
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
@@ -33,10 +36,25 @@ let package = Package(
             name: "mParticle-Rokt-Swift",
             dependencies: [
                 "mParticle-Rokt",
-                .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
-                .product(name: "Rokt-Widget", package: "Rokt-Widget"),
             ],
             path: "mParticle-Rokt-Swift"
+        ),
+        
+        .target(
+            name: "mParticle-Rokt-NoLocation",
+            dependencies: [
+              .product(name: "mParticle-Apple-SDK-NoLocation", package: "mParticle-Apple-SDK"),
+              .product(name: "Rokt-Widget", package: "Rokt-Widget"),
+            ],
+            path: "mParticle-Rokt-NoLocation",
+            publicHeadersPath: "."
+        ),
+        .target(
+            name: "mParticle-Rokt-Swift-NoLocation",
+            dependencies: [
+                "mParticle-Rokt-NoLocation",
+            ],
+            path: "mParticle-Rokt-Swift-NoLocation"
         ),
     ]
 ) 

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,10 @@
 
 import PackageDescription
 
+let mpSDK = "mParticle-Apple-SDK"
+let mpSDKNoLocation = "mParticle-Apple-SDK-NoLocation"
+let roktSDK = "Rokt-Widget"
+
 let package = Package(
     name: "mParticle-Rokt",
     platforms: [ .iOS(.v11), .tvOS(.v11) ], 
@@ -15,10 +19,10 @@ let package = Package(
             targets: ["mParticle-Rokt-Swift-NoLocation"]),
     ],
     dependencies: [
-      .package(name: "mParticle-Apple-SDK",
+      .package(name: mpSDK,
                url: "https://github.com/mParticle/mparticle-apple-sdk",
                .upToNextMajor(from: "8.0.0")),
-      .package(name: "Rokt-Widget",
+      .package(name: roktSDK,
                url: "https://github.com/ROKT/rokt-sdk-ios",
                .upToNextMajor(from: "4.10.0")),
     ],
@@ -26,8 +30,8 @@ let package = Package(
         .target(
             name: "mParticle-Rokt",
             dependencies: [
-              .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
-              .product(name: "Rokt-Widget", package: "Rokt-Widget"),
+              .product(name: mpSDK, package: mpSDK),
+              .product(name: roktSDK, package: roktSDK),
             ],
             path: "mParticle-Rokt",
             publicHeadersPath: "."
@@ -43,8 +47,8 @@ let package = Package(
         .target(
             name: "mParticle-Rokt-NoLocation",
             dependencies: [
-              .product(name: "mParticle-Apple-SDK-NoLocation", package: "mParticle-Apple-SDK"),
-              .product(name: "Rokt-Widget", package: "Rokt-Widget"),
+              .product(name: mpSDKNoLocation, package: mpSDK),
+              .product(name: roktSDK, package: roktSDK),
             ],
             path: "mParticle-Rokt-NoLocation",
             publicHeadersPath: "."

--- a/Package.swift
+++ b/Package.swift
@@ -3,20 +3,31 @@
 
 import PackageDescription
 
-let mpSDK = "mParticle-Apple-SDK"
-let mpSDKNoLocation = "mParticle-Apple-SDK-NoLocation"
+let swift = "-Swift"
+let noLocation = "-NoLocation"
+
+// MARK: - External Packages
 let roktSDK = "Rokt-Widget"
+let mpSDK = "mParticle-Apple-SDK"
+let mpSDKNoLocation = mpSDK + noLocation
+
+
+// MARK: - Names & Paths
+let mpRokt = "mParticle-Rokt"
+let mpRoktSwift = mpRokt + swift
+let mpRoktNoLocation = mpRokt + noLocation
+let mpRoktSwiftNoLocation = mpRoktSwift + noLocation
 
 let package = Package(
-    name: "mParticle-Rokt",
-    platforms: [ .iOS(.v11), .tvOS(.v11) ], 
+    name: mpRokt,
+    platforms: [ .iOS(.v11), .tvOS(.v11) ],
     products: [
         .library(
-            name: "mParticle-Rokt",
-            targets: ["mParticle-Rokt-Swift"]),
+            name: mpRokt,
+            targets: [mpRoktSwift]),
         .library(
-            name: "mParticle-Rokt-NoLocation",
-            targets: ["mParticle-Rokt-Swift-NoLocation"]),
+            name: mpRoktNoLocation,
+            targets: [mpRoktSwiftNoLocation]),
     ],
     dependencies: [
       .package(name: mpSDK,
@@ -28,37 +39,37 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "mParticle-Rokt",
+            name: mpRokt,
             dependencies: [
               .product(name: mpSDK, package: mpSDK),
               .product(name: roktSDK, package: roktSDK),
             ],
-            path: "mParticle-Rokt",
+            path: mpRokt,
             publicHeadersPath: "."
         ),
         .target(
-            name: "mParticle-Rokt-Swift",
+            name: mpRoktSwift,
             dependencies: [
-                "mParticle-Rokt",
+                .target(name: mpRokt)
             ],
-            path: "mParticle-Rokt-Swift"
+            path: mpRoktSwift
         ),
         
         .target(
-            name: "mParticle-Rokt-NoLocation",
+            name: mpRoktNoLocation,
             dependencies: [
               .product(name: mpSDKNoLocation, package: mpSDK),
               .product(name: roktSDK, package: roktSDK),
             ],
-            path: "mParticle-Rokt-NoLocation",
+            path: mpRoktNoLocation,
             publicHeadersPath: "."
         ),
         .target(
-            name: "mParticle-Rokt-Swift-NoLocation",
+            name: mpRoktSwiftNoLocation,
             dependencies: [
-                "mParticle-Rokt-NoLocation",
+                .target(name: mpRoktNoLocation)
             ],
-            path: "mParticle-Rokt-Swift-NoLocation"
+            path: mpRoktSwiftNoLocation
         ),
     ]
 ) 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,24 @@ This repository contains the Rokt integration for the [mParticle Apple SDK](http
 
 **NOTE: THESE ARE EXAMPLE INSTRUCTIONS FOR YOUR NEW KIT, THIS EXAMPLE KIT IS NOT MEANT TO BE INCLUDED IN A REAL APPLICATION**
 
-1. Add the kit dependency to your app's Podfile, Cartfile, or SPM:
+1. Add the kit dependency to your app's `Podfile` or `SPM`:
+   
 
-    ```
+   #### CocoaPods: 
+    ```ruby
     pod 'mParticle-Rokt', '~> 8.0'
+
+    # If you'd like to use a version of the mParticle SDK that doesn't include any location tracking
+    # nor links the CoreLocation framework, use this pod instead:
+    # pod 'mParticle-Rokt/SwiftNoLocation', '~> 8.0'
     ```
 
-    OR
+    #### Swift Package Manager
+    To integrate the SDK using Swift Package Manager, open your Xcode project and click on your project in the file list on the left, then select your Project in the middle of the window. Click on the **Package Dependencies** tab, and press the **"+"** button underneath the list of packages.
 
-    ```
-    github "mparticle-integrations/mparticle-apple-integration-rokt" ~> 8.0
-    ```
+    Enter the repository URL `https://github.com/mparticle-integrations/mparticle-apple-integration-rokt` in the search box on the top right, choose `mparticle-apple-integration-rokt` from the list of packages, and set the **Dependency Rule** to *Up to Next Major Version*. Then click the **Add Package** button.
+
+    Finally, choose either the package product `mParticle-Rokt`, or if you'd like to use a version of the SDK that doesn’t include any location tracking nor links the CoreLocation framework, choose `mParticle-Rokt-NoLocation`.
 
 2. Follow the mParticle iOS SDK [quick-start](https://github.com/mParticle/mparticle-apple-sdk), then rebuild and launch your app, and verify that you see `"Included kits: { Rokt }"` in your Xcode console 
 

--- a/mParticle-Rokt-NoLocation
+++ b/mParticle-Rokt-NoLocation
@@ -1,0 +1,1 @@
+mParticle-Rokt

--- a/mParticle-Rokt-Swift-NoLocation
+++ b/mParticle-Rokt-Swift-NoLocation
@@ -1,0 +1,1 @@
+mParticle-Rokt-Swift

--- a/mParticle-Rokt.podspec
+++ b/mParticle-Rokt.podspec
@@ -16,6 +16,9 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "12.0"
     
+    # Default includes both
+    s.default_subspecs = 'ObjC', 'Swift'
+    
     # Objective-C subspec
     s.subspec 'ObjC' do |objc|
         objc.source_files = 'mParticle-Rokt/*.{h,m}'
@@ -28,12 +31,7 @@ Pod::Spec.new do |s|
     s.subspec 'Swift' do |swift|
         swift.source_files = 'mParticle-Rokt-Swift/*.swift'
         swift.dependency 'mParticle-Rokt/ObjC'
-        swift.dependency 'mParticle-Apple-SDK', '~> 8.0'
-        swift.dependency 'Rokt-Widget', '~> 4.10'
     end
-    
-    # Default includes both
-    s.default_subspecs = 'ObjC', 'Swift'
     
     # Objective-C-NoLocation subspec
     s.subspec 'ObjCNoLocation' do |objc|

--- a/mParticle-Rokt.podspec
+++ b/mParticle-Rokt.podspec
@@ -34,4 +34,18 @@ Pod::Spec.new do |s|
     
     # Default includes both
     s.default_subspecs = 'ObjC', 'Swift'
+    
+    # Objective-C-NoLocation subspec
+    s.subspec 'ObjCNoLocation' do |objc|
+        objc.source_files = 'mParticle-Rokt/*.{h,m}'
+        objc.public_header_files = 'mParticle-Rokt/*.h'
+        objc.dependency 'mParticle-Apple-SDK/mParticleNoLocation', '~> 8.0'
+        objc.dependency 'Rokt-Widget', '~> 4.10'
+    end
+    
+    # SwiftNoLocation subspec
+    s.subspec 'SwiftNoLocation' do |swift|
+        swift.source_files = 'mParticle-Rokt-Swift/*.swift'
+        swift.dependency 'mParticle-Rokt/ObjCNoLocation'
+    end
 end


### PR DESCRIPTION
## Summary
 - Added a new mParticle-Rokt-NoLocation library product alongside the default integration, giving developers the option to integrate without CoreLocation dependencies. Updated Package.swift and podspec accordingly to support both variants while keeping dependencies consistent.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Verified locally that data flows successfully from the example apps to the mParticle UI Live Stream.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-35