### PR TITLE
feat: end the Rokt session when the mParticle user changes

### DIFF
--- a/mParticle-Rokt/MPKitRokt.m
+++ b/mParticle-Rokt/MPKitRokt.m
@@ -37,6 +37,12 @@ static __weak MPKitRokt *roktKit = nil;
 
 @end
 
+// Last MPID this kit acted on. Persisted rather than held in memory so a kiosk app that is
+// relaunched mid-queue still recognises the next customer as a different person; an in-memory
+// value would reset to nil on launch, be treated as a first observation, and let that customer
+// inherit the previous one's Rokt session.
+static NSString * const kMPRoktLastSeenMpidKey = @"mParticle::rokt::lastSeenMpid";
+
 @implementation MPKitRokt
 
 /*
@@ -568,6 +574,22 @@ static __weak MPKitRokt *roktKit = nil;
     return [Rokt getSessionId];
 }
 
+/// End the current Rokt session so the next placement starts a new one.
+///
+/// Reached either from MPRokt.clearSession (partner-driven) or from the session/identity
+/// triggers below.
+- (MPKitExecStatus *)clearSession {
+    [MPKitRokt clearRoktSession];
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+/// Single funnel for every reset trigger, so the ordering guarantees inside the Rokt SDK
+/// (flush buffered events, then drop the session) are exercised identically by all of them.
++ (void)clearRoktSession {
+    [MPKitRokt MPLog:@"Rokt Kit clearing the Rokt session"];
+    [Rokt clearSession];
+}
+
 #pragma mark - User attributes and identities
 
 - (MPKitExecStatus *)setUserIdentity:(NSString *)identityString identityType:(MPUserIdentity)identityType {
@@ -711,52 +733,105 @@ static __weak MPKitRokt *roktKit = nil;
 }
 
 #pragma mark Identity
+
 /*
-    Implement this method if your SDK should be notified any time the mParticle ID (MPID) changes. This will occur on initial install of the app, and potentially after a login or logout.
+    A change of MPID means a different person is using the device. On a self-service terminal
+    that is the transaction boundary: the Rokt session must end so the next customer is not
+    folded into the previous customer's session.
+
+    The kit is never told "the MPID changed" directly — MPIdentityApi fires that branch
+    internally and then forwards the identity completion unconditionally — so the comparison
+    is made here against the last MPID this kit acted on.
+
+    onModifyComplete is deliberately NOT wired: modify() resolves through
+    onModifyRequestComplete with a response carrying no mpid and forwards the current user, so
+    it cannot change the MPID and would never pass the check below.
 */
 - (MPKitExecStatus *)onIdentifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-     /*  Your code goes here.
-         If the execution is not successful, please use a code other than MPKitReturnCodeSuccess for the execution status.
-         Please see MPKitExecStatus.h for all exec status codes
-      */
-
-     return [self execStatus:MPKitReturnCodeSuccess];
+    [self clearRoktSessionIfMpidChanged:user];
+    return [self execStatus:MPKitReturnCodeSuccess];
 }
 
-/*
-    Implement this method if your SDK should be notified when the user logs in
-*/
 - (MPKitExecStatus *)onLoginComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-     /*  Your code goes here.
-         If the execution is not successful, please use a code other than MPKitReturnCodeSuccess for the execution status.
-         Please see MPKitExecStatus.h for all exec status codes
-      */
-
-     return [self execStatus:MPKitReturnCodeSuccess];
+    [self clearRoktSessionIfMpidChanged:user];
+    return [self execStatus:MPKitReturnCodeSuccess];
 }
 
-/*
-    Implement this method if your SDK should be notified when the user logs out
-*/
 - (MPKitExecStatus *)onLogoutComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-     /*  Your code goes here.
-         If the execution is not successful, please use a code other than MPKitReturnCodeSuccess for the execution status.
-         Please see MPKitExecStatus.h for all exec status codes
-      */
-
-     return [self execStatus:MPKitReturnCodeSuccess];
+    [self clearRoktSessionIfMpidChanged:user];
+    return [self execStatus:MPKitReturnCodeSuccess];
 }
 
-/*
-    Implement this method if your SDK should be notified when user identities change
-*/
-- (MPKitExecStatus *)onModifyComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {
-     /*  Your code goes here.
-         If the execution is not successful, please use a code other than MPKitReturnCodeSuccess for the execution status.
-         Please see MPKitExecStatus.h for all exec status codes
-      */
+/// Resets the Rokt session when this identity call produced a different MPID than the last one
+/// seen. The first MPID ever observed is recorded without resetting: there is no previous
+/// customer to separate from, and resetting there would discard a session the host app may
+/// have only just established.
+- (void)clearRoktSessionIfMpidChanged:(FilteredMParticleUser *)user {
+    NSNumber *mpid = user.userId;
+    if (mpid == nil || [mpid isKindOfClass:[NSNull class]]) {
+        return;
+    }
 
-     return [self execStatus:MPKitReturnCodeSuccess];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSNumber *lastSeenMpid = [defaults objectForKey:kMPRoktLastSeenMpidKey];
+    // Recorded unconditionally, and deliberately before any readiness check. Identity callbacks
+    // routinely land before Rokt's init round trip finishes; skipping the write there would leave
+    // the *next* customer looking like the first observation, so their arrival would not reset and
+    // they would inherit the previous customer's session.
+    [defaults setObject:mpid forKey:kMPRoktLastSeenMpidKey];
+
+    if (lastSeenMpid == nil) {
+        [MPKitRokt MPLog:@"Rokt Kit recording first observed MPID; no session reset"];
+        return;
+    }
+
+    if ([lastSeenMpid isEqualToNumber:mpid]) {
+        return;
+    }
+
+    [MPKitRokt MPLog:@"Rokt Kit detected an MPID change; resetting the Rokt session"];
+    // No `started` check: clearing is safe before Rokt finishes initialising (it only touches
+    // stored session state) and is exactly what a terminal relaunched mid-queue needs, so a
+    // session persisted for the previous customer is dropped rather than restored.
+    [MPKitRokt clearRoktSession];
+}
+
+#pragma mark Session
+
+/*
+    Session boundaries are only honoured when the host app drives sessions itself
+    (automaticSessionTracking == NO). Under automatic tracking a session ends after the app has
+    been in the *background* past a 60s timeout — a statement about app lifecycle, not about who
+    is using the device — and a terminal pinned in the foreground never triggers it at all. So
+    acting on automatic sessions would fragment sessions for every existing mParticle partner
+    while doing nothing for the case this exists to solve.
+
+    Both begin and end are wired. A partner rotating sessions per transaction must call
+    endSession then beginSession (beginSession is a no-op while a session exists), and honouring
+    begin as well guarantees a clean slate when a previous transaction ended abnormally. The
+    redundant reset that follows an end/begin pair is harmless: Rokt.clearSession is idempotent.
+*/
+- (MPKitExecStatus *)beginSession {
+    [self clearRoktSessionOnManualSessionBoundary];
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+- (MPKitExecStatus *)endSession {
+    [self clearRoktSessionOnManualSessionBoundary];
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+- (void)clearRoktSessionOnManualSessionBoundary {
+    if (!self.started) {
+        return;
+    }
+
+    if ([MParticle sharedInstance].automaticSessionTracking) {
+        return;
+    }
+
+    [MPKitRokt MPLog:@"Rokt Kit reached a manual session boundary; resetting the Rokt session"];
+    [MPKitRokt clearRoktSession];
 }
 
 #pragma mark Events


### PR DESCRIPTION
> **Draft — blocked on a Rokt SDK release.** This calls `Rokt.clearSession()`, which does not exist in any published Rokt SDK version yet. It will not compile until the companion SDK change ships and this kit's dependency is bumped. Everything else here compiles cleanly today.

## Problem

On a **self-service terminal** — a kiosk, counter tablet, or shared point-of-sale device — a queue of unrelated customers uses a single device. Device id, IP and every other device-level signal stay constant, and transactions can be seconds apart.

The Rokt SDK carries session identity in a token it persists and replays on every request; its gateway continues the existing session for as long as a live token is presented, and each response pushes the token's expiry forward. On a busy terminal it never lapses, so consecutive customers were all recorded against one session — meaning frequency capping, dedupe, attribution and reporting treated strangers as one person.

## Change

A change of MPID means a different person is using the device. On a shared terminal that *is* the transaction boundary, so the kit now reacts to it.

This brings the Rokt kit in line with the rest of the ecosystem — the Braze, Iterable and AppsFlyer kits all react to identity transitions, and this kit was the one leaving those callbacks empty.

### Identity triggers

`onIdentifyComplete`, `onLoginComplete` and `onLogoutComplete` share one handler that compares the incoming MPID against the last one this kit acted on, and resets only when it actually changed.

- The first MPID ever observed is recorded **without** resetting — there is no previous customer to separate from.
- The MPID is recorded **before** any readiness check. Identity callbacks routinely land before Rokt finishes initialising, and skipping the write there would leave the next customer looking like the first observation, so their arrival would not reset and they would inherit the previous customer's session.
- The value is **persisted** rather than held in memory, so a terminal relaunched mid-queue still recognises the next customer as a different person.
- `onModifyComplete` is deliberately **not** wired: `modify()` resolves through `onModifyRequestComplete` with a response carrying no mpid and forwards the current user, so it cannot change the MPID.

### Session triggers

`beginSession` / `endSession` are implemented but honoured **only** when the host app drives sessions itself (`automaticSessionTracking == NO`).

Under automatic tracking a session ends after the app has been in the *background* past a timeout — a statement about app lifecycle, not about who is using the device — and a terminal pinned in the foreground never triggers it at all. Acting on automatic sessions would fragment sessions for every existing partner while doing nothing for the case this exists to solve.

### Passthrough

`clearSession` forwards `MPRokt.clearSession` through to the Rokt SDK, for hosts that want to name the boundary themselves.

## Impact on existing integrations

This is a behaviour change for every partner on this kit, not only shared-device ones: a login or logout produces a new MPID and will now start a new Rokt session. That is intentional and was agreed as the desired behaviour — a login or logout genuinely is a different person — but it is worth calling out explicitly, since partners running placements either side of a login will see their sessions split at that point.

## Testing

The identity and session logic compiles and is unit-testable, but the `clearSession` call cannot be exercised until the Rokt SDK dependency is bumped. Kit unit tests will be added before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)